### PR TITLE
Style: Adjust billboard images

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -146,7 +146,7 @@ div.movie-list{
             auto-fit,
             minmax(230px, 1fr)
         );
-    gap: 25px;
+    gap: 50px;
     padding: 0px 10% 30px 10%;
 }
 
@@ -157,7 +157,7 @@ div.movie-list div.poster-container{
 
 div.movie-list div.poster-container img{
     width: 100%;
-    height: auto;
+    height: 100%;
 }
 
 div.movie-list div.poster-container button{
@@ -174,6 +174,7 @@ footer {
     grid-template-columns: 15% 15% 15% auto 30%;
     background-color: #ececec;
     padding-left: 6%;
+    margin-top: 2%;
     padding-bottom: 50px;
 }
 


### PR DESCRIPTION
- The billboard image's height was fixed so that everyone has the same height.
- Each movie banner's padding was adjusted to have a proper space between each one.