### PR TITLE
Style: Cinemark logo not showing on the screen

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -24,7 +24,7 @@
             </div>
         </nav>
         <nav class="shop-options">
-            <img class="logo" src="../images/cinemark_logo.png" />
+            <img class="logo" src="../resources/images/cinemark_logo.png" />
             <nav class="options">
                 <h3>Billboard</h3>
                 <h3>Theaters</h3>


### PR DESCRIPTION
## Context
The Cinemark logo wasn't been rendered as expected and it was been shown as a broken image.
## Changes
- The only change was the wrong path in the HTML document.

![image](https://github.com/MarcoAguirre/ioet-university-cinema/assets/42116904/ddb55228-330d-4b6a-9cbc-34427b8183f2)
