### PR TITLE
Feat: Cine app/get movie by id service

### DIFF
--- a/javascript/get-movie.js
+++ b/javascript/get-movie.js
@@ -1,0 +1,12 @@
+import { OPTIONS, API_MOVIE_ID_URL } from "./constants.js";
+
+export const get_movie = async(movieId) => {
+  try {
+    const urlWithMovieId = API_MOVIE_ID_URL.replace('{id}', movieId)
+    const response = await fetch(urlWithMovieId, OPTIONS);
+    const result = await response.text();
+    return JSON.parse(result).results;
+  } catch (error) {
+    throw error;
+  }
+}

--- a/test/get-movie.test.js
+++ b/test/get-movie.test.js
@@ -1,0 +1,27 @@
+import { expect, jest } from '@jest/globals';
+
+import { get_movie } from "../javascript/get-movie";
+
+function generateRandomString(length) {
+    const charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    let result = "";
+    for (let i = 0; i < length; i++) {
+      const index = Math.floor(Math.random() * charset.length);
+      result += charset[index];
+    }
+    return result;
+};
+
+it('Should return a movie', async  () => {
+    const movieId = 'tt0119217' //This id was extracted from the test API web page
+    const movie = await get_movie(movieId);
+    expect(movie).toEqual(expect.any(Object));
+    expect(movie).not.toEqual({});
+});
+
+it('Should return an error', async  () => {
+    const movieId = generateRandomString(9)
+    const movie = await get_movie(movieId);
+    expect(movie).toBeDefined();
+    expect(movie).toBe(null);
+});


### PR DESCRIPTION
 ## Context
Currently, the app just fetch all movies at once. The goal was to get a specific movie by its ID.
## Changes
- Added get_movie function to get a movie by its ID.
- Added test case to see if the response is the desired.
- Added test case which will be testing what would happen if the ID does not exist.

![image](https://github.com/MarcoAguirre/ioet-university-cinema/assets/42116904/5d2ef47b-d915-4a08-86f5-88ada9407254)
